### PR TITLE
Support botnames and emoji

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ type SlackMessage struct {
 	Channel   string `json:"channel"`
 }
 
-func ParseEventData(eventData []byte) SlackMessage {
-	// "Assumes data is in the form irc/name/icon␀msg"
+func CreateSlackMessage(eventData []byte) SlackMessage {
+	// Assumes data is in the form irc/name/icon␀msg
 	i := bytes.IndexByte(eventData, byte('\x00'))
 	if i == -1 {
 		return SlackMessage{
@@ -33,10 +33,12 @@ func ParseEventData(eventData []byte) SlackMessage {
 			"#log",
 		}
 	}
-	route := bytes.SplitN(eventData, []byte("\x00"), 2)[0]
-	text := bytes.SplitN(eventData, []byte("\x00"), 2)[1]
-	name := bytes.SplitN(route, []byte("/"), 3)[1]
-	icon := bytes.SplitN(route, []byte("/"), 3)[2]
+	splitEventData := bytes.SplitN(eventData, []byte("\x00"), 2)
+	route := splitEventData[0]
+	text := splitEventData[1]
+	splitRoute := bytes.SplitN(route, []byte("/"), 3)
+	name := splitRoute[1]
+	icon := splitRoute[2]
 	return SlackMessage{
 		string(text),
 		string(name),
@@ -51,7 +53,7 @@ func SendToSlack(eventData []byte) {
 		return
 	}
 
-	msg := ParseEventData(eventData)
+	msg := CreateSlackMessage(eventData)
 	jsonMsg, _ := json.Marshal(msg)
 	msgReader := bytes.NewReader(jsonMsg)
 

--- a/main.go
+++ b/main.go
@@ -23,7 +23,8 @@ type SlackMessage struct {
 }
 
 func CreateSlackMessage(eventData []byte) SlackMessage {
-	// Assumes data is in the form irc/name/icon␀msg
+	// Assumes topic is of the form domain/name/icon␀msg
+	// but domain is ignored (should probably be slack.scraperwiki.com)
 	i := bytes.IndexByte(eventData, byte('\x00'))
 	if i == -1 {
 		return SlackMessage{


### PR DESCRIPTION
Recieved messages are of the form /irc/botname/:emoji:␀message
where botname, emoji and message are parameters and irc is literal.

Note that slack doesn't show a new icon if the icon has changed but
the last message was from the same name.
